### PR TITLE
Add WordPress.org deployment and asset update workflows

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,10 +1,14 @@
 .distignore
 .editorconfig
+.git/
 .gitattributes
+.github/
 .gitignore
+.idea/
 .nvmrc
 .prettierignore
 .wp-env.json
+.wp-env.override.json
 CHANGELOG.md
 README.md
 artifacts/
@@ -15,6 +19,7 @@ eslint.config.cjs
 node_modules/
 package.json
 package-lock.json
+src/
 tests/
 tsconfig.json
 vendor/

--- a/.github/workflows/deploy-dotorg.yml
+++ b/.github/workflows/deploy-dotorg.yml
@@ -1,0 +1,41 @@
+name: Deploy to WordPress.org
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Setup Node
+      uses: actions/setup-node@v7
+      with:
+        node-version-file: '.nvmrc'
+        cache: npm
+
+    - name: Install dependencies
+      run: npm ci
+
+    - name: Build plugin
+      run: npm run build
+
+    - name: WordPress plugin deploy
+      uses: 10up/action-wordpress-plugin-deploy@stable
+      id: deploy
+      with:
+        generate-zip: true
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        SLUG: disable-embeds
+
+    - name: Upload release asset
+      run: gh release upload ${{ github.event.release.tag_name }} ${{ steps.deploy.outputs.zip-path }}
+      env:
+        GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}

--- a/.github/workflows/update-dotorg-assets.yml
+++ b/.github/workflows/update-dotorg-assets.yml
@@ -1,0 +1,24 @@
+name: Update assets on WordPress.org
+
+on:
+  push:
+    branches:
+    - main
+
+jobs:
+  update:
+    name: Update assets
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v7
+
+    - name: Update assets
+      uses: 10up/action-wordpress-plugin-asset-update@stable
+      env:
+        SVN_USERNAME: ${{ secrets.SVN_USERNAME }}
+        SVN_PASSWORD: ${{ secrets.SVN_PASSWORD }}
+        IGNORE_OTHER_FILES: true
+        # This repo has no .wordpress-org directory yet, so only readme.txt
+        # is synced. Drop this once banner and icon assets are added.
+        SKIP_ASSETS: true


### PR DESCRIPTION
## Summary
This PR adds GitHub Actions workflows to automate the deployment of the plugin to WordPress.org and keep plugin assets synchronized.

## Key Changes
- **Deploy to WordPress.org workflow** (`deploy-dotorg.yml`): Automatically publishes plugin releases to WordPress.org when a release is published on GitHub. The workflow:
  - Checks out the code and sets up Node.js
  - Installs dependencies and builds the plugin
  - Deploys to WordPress.org SVN repository using 10up's deploy action
  - Uploads the generated zip file as a release asset on GitHub

- **Update assets workflow** (`update-dotorg-assets.yml`): Automatically syncs plugin assets (readme.txt) to WordPress.org when changes are pushed to the main branch

- **Updated `.distignore`**: Expanded the distribution ignore list to exclude:
  - Git-related files and directories (`.git/`, `.github/`, `.gitattributes`, `.gitignore`)
  - Development configuration files (`.idea/`, `.wp-env.override.json`)
  - Source files (`src/`) to ensure only built/compiled assets are distributed

## Implementation Details
- Both workflows use the stable versions of 10up's WordPress plugin actions
- Deployment requires `SVN_USERNAME` and `SVN_PASSWORD` secrets configured in the repository
- Asset updates skip the `.wordpress-org` directory assets (banner/icon) as noted in the comment, with a plan to enable them once assets are added
- The `.distignore` changes ensure development and source files are excluded from the distributed plugin package

https://claude.ai/code/session_013NqAxZqiBuaRKCXvbhMtVs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release packaging by excluding repository metadata, configuration files, and source files from distributable archives.
  * Added automated deployment of published releases to WordPress.org.
  * Added automated synchronization of the WordPress.org readme file when changes reach the main branch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->